### PR TITLE
auto-create generic install script for all nuspecs

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,6 @@ function Copy-InstallScripts {
     Copy-Item -Path '.\scripts\*' -Destination $artifactsDir
 }
 
-
 function Build-GenericInstallScript {
     $validateSet = @()
     foreach ($nuspec in Get-ChildItem -Path '.\nuspec\**\*.nuspec') {


### PR DESCRIPTION
stumbled upon this when adding my first package (custom `.nuspec`)
- you'd have to create a fresh `install-whatever.ps1` for each package you'd add

with this PR, a new `install.ps1` is added that includes a validate-set for all available packages.