### PR TITLE
pause only on error

### DIFF
--- a/scripts/install-mybox.bat
+++ b/scripts/install-mybox.bat
@@ -1,3 +1,6 @@
 @ECHO OFF
 PowerShell.exe -NoProfile -Command "& {Start-Process PowerShell.exe -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File ""%~dpn0.ps1""' -Verb RunAs}"
-PAUSE
+if NOT ["%errorlevel%"]==["0"] (
+    PAUSE
+    exit /b %errorlevel%
+)


### PR DESCRIPTION
using `pause` only on error allows this script to be used in automated environments.